### PR TITLE
Overflow fixes for small viewports

### DIFF
--- a/frontend/src/score-subject-stats.ts
+++ b/frontend/src/score-subject-stats.ts
@@ -492,6 +492,8 @@ export class ScoreSubjectStatsComponent extends LitElement {
 
 		.flex {
 			display: flex;
+			flex-wrap: wrap;
+			column-gap: 1rem;
 		}
 		.flexitem {
 			flex: 1;
@@ -506,12 +508,7 @@ export class ScoreSubjectStatsComponent extends LitElement {
 		}
 
 		.flex .box {
-			flex: 1;
-			margin-right: 16px;
-		}
-
-		.flex .box:last-child {
-			margin-right: 0;
+			flex-grow: 1;
 		}
 
 		.legend {

--- a/frontend/src/score-wm.ts
+++ b/frontend/src/score-wm.ts
@@ -111,6 +111,7 @@ export class WindowManager extends LitElement {
 			background-color: #ecf0f5;
 			display: grid;
 			box-sizing: border-box;
+			overflow-x: hidden;	
 		}
 
 		.in {


### PR DESCRIPTION
On small viewports, the score view can have a horizontal overflow caused by a the `flex` class not being `wrap`able. This PR addresses that issue by allowing the flex items to wrap and grow to re-fit the container.

This PR also addresses horizontal scrollbars appearing during page transitions. I can remove it if it does not fit the scope of this PR.